### PR TITLE
Eliminating Ruby warnings

### DIFF
--- a/lib/predicated/print.rb
+++ b/lib/predicated/print.rb
@@ -6,11 +6,11 @@ module Predicated
 
     private
     def part_to_s(thing)
-      part_to_str(thing) {|thing| thing.to_s}
+      part_to_str(thing) {|t| t.to_s}
     end
     
     def part_inspect(thing, indent="")
-      part_to_str(thing, indent) {|thing| thing.inspect(indent)}
+      part_to_str(thing, indent) {|t| t.inspect(indent)}
     end
     
     def part_to_str(thing, indent="")

--- a/lib/predicated/to/sentence.rb
+++ b/lib/predicated/to/sentence.rb
@@ -50,7 +50,7 @@ module Predicated
 
       register_verb_phrase(:include?, "includes", "does not include")
       register_verb_phrase(:is_a?, "is a", "is not a")
-      register_verb_phrase(:nil?, "is nil", "is not nil", accepts_object=false)
+      register_verb_phrase(:nil?, "is nil", "is not nil", false)
       
       nil
     end


### PR DESCRIPTION
Similar to https://github.com/sconover/wrong/pull/44.
Here's a fix for some other Ruby warnings when executed via wrong.
